### PR TITLE
Fix: Remove duplicate close button in AboutModal

### DIFF
--- a/client/src/components/AboutModal.tsx
+++ b/client/src/components/AboutModal.tsx
@@ -30,14 +30,6 @@ export default function AboutModal({ open, onOpenChange }: AboutModalProps) {
           <DialogDescription className="text-center">
             A modern visual code-snippet manager
           </DialogDescription>
-
-          <button
-            onClick={() => onOpenChange(false)}
-            className="absolute right-4 top-4 rounded-sm p-1 opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring"
-          >
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
-          </button>
         </DialogHeader>
 
         <section className="space-y-6 py-4 text-sm">


### PR DESCRIPTION
The AboutModal component was rendering a close button within its DialogHeader, while the DialogContent component (from ui/dialog) already provides a close button. This resulted in two overlapping close buttons.

This commit removes the redundant close button from AboutModal.tsx, leaving the one provided by DialogContent, which is correctly positioned and functional.