### PR TITLE
Fix: Configure Vite to correctly serve favicons

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig(async () => {
       outDir:      path.resolve(import.meta.dirname, "dist/public"),
       emptyOutDir: true,
     },
+    publicDir: path.resolve(import.meta.dirname, "public"),
 
     /* ----------------------------------------------------------
      * Env handling


### PR DESCRIPTION
The favicon was not displaying because Vite's `root` was set to `client/`, causing it to look for the `public/` directory within `client/` by default.

This commit updates `vite.config.ts` to explicitly set `publicDir` to point to the `public/` directory at the project root. This ensures that Vite can find and serve the favicon files and other static assets correctly.