### PR TITLE
Enable Winston logging for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",
+  "sideEffects": ["./server/logger.ts"],
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,13 +11,13 @@ import helmet from "helmet";
 import camelCase from "camelcase";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic } from "./vite";
-import logger from "./logger.js";
+import logger from "./logger";
 
 
 /* ────────────────────────────────────────────────────────────────── */
 /* 0. Winston test log – confirms logger is active                    */
 /* ────────────────────────────────────────────────────────────────── */
-logger.info("✅ Winston logger initialized: /home/zk/logs/codepatchwork.log");
+logger.info("✅ Winston logger loaded from ./logger.ts");
 logger.info("🧪 Logger test: Express server startup log");
 
 /* ────────────────────────────────────────────────────────────────── */
@@ -250,6 +250,7 @@ app.use((req, res, next) => {
   }
 
   const port = Number(process.env.PORT) || 3001;
+  logger.info(`🚀 Express server starting on port ${process.env.PORT || 3001}`);
   server.listen({ host: "0.0.0.0", port, reusePort: true }, () => {
     logger.info(`🚀 Serving on port ${port}`);
     logger.info(`📡 API available at http://localhost:${port}/api/`);

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,9 +1,7 @@
-// logger.js — Drop-in Winston logger with safety checks and startup test log
 import fs from 'fs';
 import path from 'path';
 import { createLogger, format, transports } from 'winston';
 
-// Ensure log directory exists
 const logDir = '/home/zk/logs';
 const logFile = path.join(logDir, 'codepatchwork.log');
 
@@ -16,39 +14,25 @@ if (!fs.existsSync(logDir)) {
   }
 }
 
-// Define transports
-const transportList = [
-  new transports.Console(),
-];
-
-try {
-  transportList.push(
-    new transports.File({ filename: logFile })
-  );
-} catch (err) {
-  console.error("❌ Could not create file transport for Winston:", err);
-}
-
-// Create the logger
 const logger = createLogger({
   level: 'info',
   format: format.combine(
-    format.colorize(),
     format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
     format.printf(({ timestamp, level, message, ...meta }) => {
       const metaString = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
       return `${timestamp} [${level}]: ${message}${metaString}`;
     })
   ),
-  transports: transportList
+  transports: [
+    new transports.Console(),
+    new transports.File({ filename: logFile })
+  ]
 });
 
-// Handle internal Winston errors
 logger.on('error', (err) => {
-  console.error("❌ Winston internal logging error:", err);
+  console.error('❌ Winston internal logging error:', err);
 });
 
-// 🔧 Initial test log
-logger.info("🧪 Winston logger initialized and ready.");
+logger.info('🧪 Winston logger initialized and ready.');
 
 export default logger;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,7 +6,7 @@ import type { DecodedIdToken }                      from "firebase-admin/auth";
 import { pool }                                     from "./db";
 import { storage }                                  from "./storage";
 import { simpleStorage }                            from "./simple-storage";
-import logger                                       from "./logger.js";
+import logger                                       from "./logger";
 import {
   insertSnippetSchema,
   insertCollectionSchema,

--- a/server/winston-test.js
+++ b/server/winston-test.js
@@ -1,5 +1,5 @@
 // winston-test.js
-import logger from './logger.js';
+import logger from './logger';
 
 logger.info("✅ Winston basic test: info level");
 logger.warn("⚠️ Winston basic test: warn level");


### PR DESCRIPTION
## Summary
- convert `server/logger.js` to TypeScript and keep console+file transports
- import new logger in server modules
- log startup info in `server/index.ts`
- prevent esbuild from pruning logger via `sideEffects`
- update winston test script

## Testing
- `npm run build` *(fails: vite not found)*
- `pm2 restart codepatchwork --update-env` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cf83634083228d38a727c9e3aa01