### PR TITLE
Fix Winston logs after esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,15 @@ For local development, you'll need Node.js 18+ and PostgreSQL. See detailed setu
 
 - `npm run dev` - Start development server
 - `npm run build` - Build for production
+- `npm run test:logger` - Verify Winston file logging in `dist`
 - `npm run db:push` - Push schema changes to database
 - `npm run db:studio` - Open Drizzle Studio to manage database
+
+### Quick Logger Test
+
+After running `npm run build`, execute `npm run test:logger` to verify that
+`/home/zk/logs/codepatchwork.log` is created. The test script writes a few
+messages using the bundled logger to ensure file logging works in production.
 
 ## 📝 License
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "sideEffects": ["./server/logger.ts"],
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts server/winston-test.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "test:logger": "node dist/winston-test.js",
     "start": "NODE_ENV=production node -r dotenv/config dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -14,6 +14,20 @@ if (!fs.existsSync(logDir)) {
   }
 }
 
+const fileTransport = new transports.File({ filename: logFile });
+
+fileTransport.on('error', err => {
+  console.error('⚠️ File transport error:', err.message);
+  try {
+    fs.appendFileSync(
+      path.join(logDir, 'fallback.log'),
+      `[${new Date().toISOString()}] Logger failed: ${err.message}\n`
+    );
+  } catch (appendErr) {
+    console.error('⚠️ Fallback logging failed:', (appendErr as Error).message);
+  }
+});
+
 const logger = createLogger({
   level: 'info',
   format: format.combine(
@@ -25,7 +39,7 @@ const logger = createLogger({
   ),
   transports: [
     new transports.Console(),
-    new transports.File({ filename: logFile })
+    fileTransport
   ]
 });
 

--- a/server/winston-test.ts
+++ b/server/winston-test.ts
@@ -1,4 +1,4 @@
-// winston-test.js
+// winston-test.ts
 import logger from './logger';
 
 logger.info("✅ Winston basic test: info level");


### PR DESCRIPTION
## Summary
- preserve `logger.ts` side effects with `sideEffects`
- add Winston file transport fallback and error handling
- compile winston-test file with server build
- expose `test:logger` script
- document logger test instructions

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test:logger` *(fails: module not found because build failed)*

------
https://chatgpt.com/codex/tasks/task_e_6858d9dc10848322bcf42da03cafb693