### PR TITLE
Silence logs in production

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,6 +7,11 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
 
+// Disable console.log in production to avoid verbose output
+if (process.env.NODE_ENV === "production") {
+  console.log = () => {};
+}
+
 const root = createRoot(document.getElementById("root")!);
 root.render(
   <QueryClientProvider client={queryClient}>

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,11 @@ import { setupVite, serveStatic } from "./vite";
 import logger from "./logger";
 import "./logger.ts"; // force esbuild to preserve it
 
+// Disable console.log in production to avoid verbose output
+if (process.env.NODE_ENV === "production") {
+  console.log = () => {};
+}
+
 
 /* ────────────────────────────────────────────────────────────────── */
 /* 0. Winston test log – confirms logger is active                    */


### PR DESCRIPTION
## Summary
- disable console.log for production in server and client

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test:logger` *(fails: dist/winston-test.js missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c676521648322a7623308f8bab46a